### PR TITLE
Fix: process all messages in onMessagesUpsert function

### DIFF
--- a/src/middlewares/onMesssagesUpsert.js
+++ b/src/middlewares/onMesssagesUpsert.js
@@ -6,12 +6,13 @@ exports.onMessagesUpsert = async ({ socket, messages }) => {
     return;
   }
 
-  const webMessage = messages[0];
-  const commonFunctions = loadCommomFunctions({ socket, webMessage });
+  for (const webMessage of messages) {
+    const commonFunctions = loadCommomFunctions({ socket, webMessage });
 
-  if (!commonFunctions) {
-    return;
+    if (!commonFunctions) {
+      continue;
+    }
+
+    await dynamicCommand(commonFunctions);
   }
-
-  await dynamicCommand(commonFunctions);
 };


### PR DESCRIPTION
Updated onMessagesUpsert to handle all incoming messages in the array, not just the first one. Added a loop to ensure each message is processed, improving handling of multiple messages in Baileys.