### PR TITLE
fix: bot responding to itself when sending a link

### DIFF
--- a/src/utils/dynamicCommand.js
+++ b/src/utils/dynamicCommand.js
@@ -33,6 +33,8 @@ exports.dynamicCommand = async (paramsHandler) => {
   } = paramsHandler;
 
   if (isActiveAntiLinkGroup(remoteJid) && isLink(fullMessage)) {
+    if (!userJid) return
+    
     if (!(await isAdmin({ remoteJid, userJid, socket }))) {
       await socket.groupParticipantsUpdate(remoteJid, [userJid], "remove");
 


### PR DESCRIPTION
Salve man!
Quando está com o antilink ativado e o bot enviar um link, ele manda a própria mensagem "Anti-link ativado! Você foi removido por enviar um link!".

Uns 35 segundos depois, aparece o seguinte erro no terminal:

```sh
D:\sky-bot\node_modules\baileys\lib\Utils\generics.js:170
            .then(() => reject(new boom_1.Boom('Timed Out', {
                               ^

Error: Timed Out
    at D:\sky-bot\node_modules\baileys\lib\Utils\generics.js:170:32 {
  data: {
    stack: 'Error\n' +
      '    at promiseTimeout (D:\\sky-bot\\node_modules\\baileys\\lib\\Utils\\generics.js:165:19)\n' +
      '    at waitForMessage (D:\\sky-bot\\node_modules\\baileys\\lib\\Socket\\socket.js:117:53)\n' +
      '    at query (D:\\sky-bot\\node_modules\\baileys\\lib\\Socket\\socket.js:139:22)\n' +
      '    at groupQuery (D:\\sky-bot\\node_modules\\baileys\\lib\\Socket\\groups.js:12:55)\n' +
      '    at Object.groupParticipantsUpdate (D:\\sky-bot\\node_modules\\baileys\\lib\\Socket\\groups.js:142:34)\n' +
      '    at exports.dynamicCommand (D:\\sky-bot\\src\\utils\\dynamicCommand.js:41:17)\n' +
      '    at async exports.onMessagesUpsert (D:\\sky-bot\\src\\middlewares\\onMessagesUpsert.js:12:5)'
  },
  isBoom: true,
  isServer: false,
  output: {
    statusCode: 408,
    payload: {
      statusCode: 408,
      error: 'Request Time-out',
      message: 'Timed Out'
    },
    headers: {}
  }
}

Node.js v22.8.0
```

Aplicando o console.log() nos 2 parâmetros (remoteJid e userJid), o userJid não retorna nada quando a mensagem é do próprio bot.