### PR TITLE
@cacheable/node-cache added and removed the "readline" dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.4.0",
       "license": "ISC",
       "dependencies": {
+        "@cacheable/node-cache": "^1.5.3",
         "axios": "^1.7.7",
         "baileys": "6.7.16",
         "correios-brasil": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@cacheable/node-cache": "^1.5.3",
     "axios": "^1.7.7",
     "baileys": "6.7.16",
     "correios-brasil": "^3.0.6",
     "hercai": "^12.4.0",
-    "pino": "^9.5.0",
-    "readline": "^1.3.0"
+    "pino": "^9.5.0"
   }
 }

--- a/src/connection.js
+++ b/src/connection.js
@@ -28,7 +28,7 @@ const {
   makeInMemoryStore,
   isJidNewsletter,
 } = require("baileys");
-const NodeCache = require("node-cache");
+const { NodeCache } = require("@cacheable/node-cache");
 const pino = require("pino");
 const { load } = require("./loader");
 const {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,7 +8,7 @@ const { PREFIX, COMMANDS_DIR, TEMP_DIR } = require("../config");
 const path = require("path");
 const fs = require("fs");
 const { writeFile } = require("fs/promises");
-const readline = require("readline");
+const readline = require("node:readline");
 const axios = require("axios");
 
 exports.question = (message) => {


### PR DESCRIPTION
Changed node-cache to @cacheable/node-cache to repair module not found and removed the "readline" dependency, NodeJS has it internally since version 0.7.7